### PR TITLE
Your setSwitch command.

### DIFF
--- a/src/main/java/wayside/Decider.java
+++ b/src/main/java/wayside/Decider.java
@@ -141,6 +141,11 @@ public class Decider {
         return track[blockId].crossing;
     }
 
+    boolean setSwitch(int blockId, boolean value) {
+        track[blockId].switchState = value;
+        return value;
+    }
+
     boolean getSwitch(int blockId) {
         return track[blockId].switchState;
     }

--- a/src/main/java/wayside/Decider.java
+++ b/src/main/java/wayside/Decider.java
@@ -118,18 +118,16 @@ public class Decider {
      * @return Wether the suggested authority is safe for switches.
      */
     boolean checkSwitches() {
-        // for all switches...
         for (WCSwitch sw: st.getSwitches()) {
-            int root = sw.root;
-            int def = sw.def;
-            int active = sw.active;
-            if (suggestedAuthority[def] && suggestedAuthority[active]) {
+            if (suggestedAuthority[sw.def] && suggestedAuthority[sw.active]) {
                 // both default and active branch cannot have authority
                 return false;
             }
             // which way should the switch go?
-            if (suggestedAuthority[active]) {
-                track[root].switchState = true;
+            if (suggestedAuthority[sw.active]) {
+                track[sw.root].switchState = true;
+            } else if (suggestedAuthority[sw.root] || suggestedAuthority[sw.def]) {
+                track[sw.root].switchState = false;
             }
         }
         return true;

--- a/src/main/java/wayside/WaysideController.java
+++ b/src/main/java/wayside/WaysideController.java
@@ -158,6 +158,17 @@ public class WaysideController {
     public static boolean getSignal(int blockId) {
         return tm.getSignal(blockId);
     }
+
+    /**
+     * Accepts a switch position suggestion from CTC.
+     * Will only preserve this suggestion if authority is not requested over it.
+     * @param blockId the line-specific number of the block in question.
+     * @param value the position which is being requested.
+     * @return the given value.
+     */
+    public static boolean setSwitch(int blockId, boolean value) {
+        return decider.setSwitch(blockId, value);
+    }
     
     /**
      * Checks the TrackModel to determine if a switch is active.

--- a/src/test/java/wayside/GreenLine.java
+++ b/src/test/java/wayside/GreenLine.java
@@ -121,4 +121,74 @@ public class GreenLine {
         assertFalse(decider.getSwitch(63));
     }
 
+
+    @Test
+    public void twoSuggDefaultThenActiveSwitch() {
+        // First we're using default branch
+        tm.occupy(62, true);
+        squash(new Suggestion[] {
+            new Suggestion(62, 10, new int[] {62, 63, 64})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertFalse(decider.getSwitch(63));
+        // Then the active one.
+        tm.occupy(62, false);
+        tm.occupy(152, true);
+        squash(new Suggestion[] {
+            new Suggestion(152, 10, new int[] {152, 63, 64})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(63));
+    }
+
+    @Test
+    public void setSwitchNoOverlapingUse() {
+        decider.setSwitch(13, true);
+        tm.occupy(62, true);
+        squash(new Suggestion[] {
+            new Suggestion(62, 10, new int[] {62, 63})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(13));
+        assertFalse(decider.getSwitch(63));
+    }
+
+    @Test
+    public void setSwitchAuthorityAgrees() {
+        decider.setSwitch(63, true);
+        tm.occupy(152, true);
+        squash(new Suggestion[] {
+            new Suggestion(152, 10, new int[] {152, 63})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(63));
+    }
+
+    @Test
+    public void setSwitchAuthorityDisagrees() {
+        decider.setSwitch(63, true);
+        tm.occupy(62, true);
+        squash(new Suggestion[] {
+            new Suggestion(62, 10, new int[] {62, 63})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertFalse(decider.getSwitch(63));
+    }
+
+    @Test
+    public void setSwitchChangeFromPreviousActive() {
+        tm.occupy(152, true);
+        squash(new Suggestion[] {
+            new Suggestion(152, 10, new int[] {152, 63, 64})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(63));
+        decider.setSwitch(63, false);
+        squash(new Suggestion[] {
+            new Suggestion(1, 10, new int[] {1, 13, 14})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(13));
+        assertFalse(decider.getSwitch(63));
+    }
 }

--- a/src/test/java/wayside/GreenLine.java
+++ b/src/test/java/wayside/GreenLine.java
@@ -104,4 +104,21 @@ public class GreenLine {
         assertTrue(decider.suggest(auth, speed));
     }
 
+    @Test
+    public void twoSuggActiveThenDefaultSwitch() {
+        tm.occupy(152, true);
+        squash(new Suggestion[] {
+            new Suggestion(152, 10, new int[] {152, 63, 64})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertTrue(decider.getSwitch(63));
+        tm.occupy(152, false);
+        tm.occupy(62, true);
+        squash(new Suggestion[] {
+            new Suggestion(62, 10, new int[] {62, 63, 64})
+        });
+        assertTrue(decider.suggest(auth, speed));
+        assertFalse(decider.getSwitch(63));
+    }
+
 }


### PR DESCRIPTION
Because Decider keeps track of what its outputs on the track currently are, but changes them as needed, it was pretty easy to simply write into that state, so that if I didn't need to modify it (because someone wanted authority on the switch), then the suggestion would still be there.